### PR TITLE
 Moved scripts to the root directory, and moved cfg to cfg.example.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Site specific config file
+chrooms.cfg

--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@ Chrooms
 
 Chrooms (short for "Changing Rooms") glues together a Team Fortress 2 (TF2) server and a Mumble server, moving users to the Mumble chat room corresponding to the team they are playing on at the moment. Chrooms might also work for Source games other than TF2.
 
-Installation instructions:
+Installation instructions
+-------------------------
 
 0. Install EventScripts on the TF2 server by extracting [build 379](http://forums.eventscripts.com/viewtopic.php?p=407186#p407186) to the directory `tf/`. (The forum post says that build 379 is intended for Counter Strike, but using this version seems to be the only way to get it to work for TF2.) EventScripts generates an error message when the TF2 server starts, but it doesn't affect us.
-0. Install Chrooms by copying `chrooms/chrooms/` to `tf/addon/eventscripts/`.
+0. Get chrooms by running `git clone https://github.com/JonasOlson/chrooms.git` in a directory of your choice.
+0. Create a symbolic link to `chrooms/chrooms` from `tf/addons/eventscripts/chrooms` by running `ln -s chrooms/chrooms tf/addons/eventscripts/chrooms`. The exact path to the tf directory depends on where your TF2-server is installed.
+0. Copy the example config `tf/addons/eventscripts/chrooms/chrooms.cfg.example` to `tf/addons/eventscripts/chrooms/chrooms.cfg`.
 0. Configure Chrooms in `tf/addon/eventscripts/chrooms/chrooms.cfg`. A password (also called "secret") for administration of the Mumble server is set with `icesecretwrite` in `/etc/mumble-server.ini`. Set the same secret in the configuration file for Chrooms. (Note that `icesecretwrite` must be commented out if you want the Mumble server to require no password.)
 0. Chooms is turned on and off with the following commands in the TF2 server console:
 

--- a/chrooms/chrooms.cfg.example
+++ b/chrooms/chrooms.cfg.example
@@ -1,10 +1,10 @@
 [Mumble]
 
 # Details for connecting to the Mumble server
-host: localhost
+host: mumble.example.com
 port: 6502
-secret:
+secret: hunter2
 
 # Names of the Mumble chat rooms for the two TF2 teams
-BLU_room: Byggarnas allians 
+BLU_room: Byggarnas allians
 RED_room: Driftsäker utgrävning och demolering


### PR DESCRIPTION
The motivations are as follows:
- Having the actual code in the root directory allows the user to clone the project directly into the ES-folder and making the config file. That way there's no need to copy any folders, updating is a simple matter of git pull.
- In order to prevent the site specific config file to be over written on git pull, or sensitive information being leaked by an accidental commit of the cfg file, making a difference between the repo example and the site conf is necessary. This is common practice.

I hope you will find these modifications agreeable.
